### PR TITLE
Bump influxdb-java from version 2.9 to 2.21

### DIFF
--- a/kafka-connect-influxdb/build.gradle
+++ b/kafka-connect-influxdb/build.gradle
@@ -17,7 +17,7 @@
 project(":kafka-connect-influxdb") {
 
     ext {
-        influxDbVersion = "2.9"
+        influxDbVersion = "2.21"
     }
 
     dependencies {


### PR DESCRIPTION
- Update the influxdb-java dependency, in particular need a fix introduced in 2.16 which skips fields with NaN and Infinity values when writing to InfluxDB.